### PR TITLE
feat: cache existing immutable assets

### DIFF
--- a/tests/worker/routing.worker.test.ts
+++ b/tests/worker/routing.worker.test.ts
@@ -27,4 +27,29 @@ describe("production host routing", () => {
     expect(response.headers.get("location")).toBe("https://aamirazad.com/admin?from=www");
     expect(response.headers.get("cache-control")).toBe("private, no-store");
   });
+
+  it("caches only immutable assets that actually exist", async () => {
+    const page = await SELF.fetch("https://aamirazad.com/");
+    const html = await page.text();
+    const entrypoint = html.match(
+      /import\("(\.\/_app\/immutable\/entry\/start\.[^"]+\.js)"\)/,
+    )?.[1];
+
+    expect(entrypoint).toBeTruthy();
+
+    const [existing, missing] = await Promise.all([
+      SELF.fetch(new URL(entrypoint!, "https://aamirazad.com/")),
+      SELF.fetch("https://aamirazad.com/_app/immutable/entry/missing.js"),
+    ]);
+
+    expect(existing.status).toBe(200);
+    expect(existing.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+    expect(existing.headers.get("cloudflare-cdn-cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+
+    expect(missing.status).toBe(404);
+    expect(missing.headers.get("cache-control")).toBe("no-store");
+    expect(missing.headers.get("cloudflare-cdn-cache-control")).toBe("no-store");
+  });
 });

--- a/worker.ts
+++ b/worker.ts
@@ -9,12 +9,19 @@ import { PublishWorkflow } from "./src/lib/server/content/publish-workflow";
 
 export { PublishWorkflow };
 
+const IMMUTABLE_ASSET_PREFIX = "/_app/immutable/";
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const MISSING_ASSET_CACHE_CONTROL = "no-store";
+
 export default class PublicWorker extends WorkerEntrypoint<Env> {
   async fetch(request: Request): Promise<Response> {
     const env = this.env;
     const ctx = this.ctx;
     const applicationRequest = normalizeWorkersDevRequestProtocol(request);
     const incomingUrl = new URL(applicationRequest.url);
+    if (incomingUrl.pathname.startsWith(IMMUTABLE_ASSET_PREFIX)) {
+      return immutableAssetResponse(await env.ASSETS.fetch(applicationRequest));
+    }
     const canonicalOrigin = new URL(env.APP_ORIGIN);
     if (
       incomingUrl.hostname === "www.aamirazad.com" &&
@@ -52,4 +59,13 @@ function isPrivatePath(pathname: string): boolean {
   return ["/admin", "/api", "/auth", "/preview"].some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   );
+}
+
+function immutableAssetResponse(asset: Response): Response {
+  const response = new Response(asset.body, asset);
+  const found = asset.status === 200 || asset.status === 206 || asset.status === 304;
+  const cacheControl = found ? IMMUTABLE_CACHE_CONTROL : MISSING_ASSET_CACHE_CONTROL;
+  response.headers.set("cache-control", cacheControl);
+  response.headers.set("cloudflare-cdn-cache-control", cacheControl);
+  return response;
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,7 +7,7 @@
   "assets": {
     "binding": "ASSETS",
     "directory": ".svelte-kit/cloudflare",
-    "run_worker_first": ["/*", "!/_app/immutable/*", "!/favicon.svg", "!/robots.txt", "!/ssh"],
+    "run_worker_first": ["/*", "!/favicon.svg", "!/robots.txt", "!/ssh"],
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Cache existing SvelteKit immutable assets for one year with `immutable` directives.
- Prevent missing immutable assets from being cached by returning `no-store` headers.
- Route immutable asset requests through the Worker for status-aware cache headers.

## Testing

- Added routing coverage for existing and missing immutable assets.
- Not run.